### PR TITLE
Use JSON content type to submit the report

### DIFF
--- a/lib/benchmark/ips/share.rb
+++ b/lib/benchmark/ips/share.rb
@@ -15,7 +15,7 @@ module Benchmark
         base = (ENV['SHARE_URL'] || DEFAULT_URL)
         url = URI(File.join(base, "reports"))
 
-        req = Net::HTTP::Post.new(url)
+        req = Net::HTTP::Post.new(url, initheader = {'Content-Type' =>'application/json'})
 
         data = {
           "entries" => @report.data,


### PR DESCRIPTION
This PR updates the Share module to set a JSON content type header so the benchmark-fyi Rails app understands the params properly after the refactor we are doing there.